### PR TITLE
ハワユ実装＋keyの名前変更

### DIFF
--- a/laravel/resources/js/pages/hawayu/Hawayu.jsx
+++ b/laravel/resources/js/pages/hawayu/Hawayu.jsx
@@ -92,7 +92,7 @@ const Hawayu = () =>{
                                         </Box>
                                        {q.question}
                                        <Select placeholder="回答を選ぶ" 
-                                       name={q.id}
+                                       name={"A"+q.id}
                                        onChange={ onChangeSetData }>
                                             {q.answers.map((a)=>
                                             <option value={a.id} key={a.id}>{a.answer}</option> 

--- a/laravel/resources/js/pages/hawayu/Hawayu.jsx
+++ b/laravel/resources/js/pages/hawayu/Hawayu.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState,useContext } from 'react';
+import axios from 'axios';
+import styled from 'styled-components';
+import { useHistory} from 'react-router-dom';
+import {
+    IconButton,Button,ButtonGroup,Box,ChakraProvider,Badge,
+    FormControl,FormLabel,
+    Container,Select,Image,Center
+  } from "@chakra-ui/react"
+import { ArrowRightIcon,ArrowBackIcon } from '@chakra-ui/icons'
+
+import question1 from './question1.png';
+import question2 from './question2.png';
+import question3 from './question3.png';
+import question4 from './question4.png';
+import { valuesIn } from 'lodash';
+
+
+const Hawayu = () =>{
+    const history = useHistory();
+    const  [question, setQuestion] = useState([]);
+    const  [answerData, setAnswerData] = useState([]);
+
+    const pictures = [question1,question2,question3,question4]
+
+    const api_token = document
+        .querySelector('meta[name="api-token"]')
+        .getAttribute("content")
+
+    const csrf_token = document
+        .querySelector('meta[name="csrf-token"]')
+        .getAttribute("content")
+        
+    // const onClickCreateQuestion = async() =>{
+    //     await axios.post("/api/create-inquiry",{api_token},{csrf_token})
+    // .then((res)=>{
+    //     console.log("create",res.data)   
+    //     onClickShowQuestion();
+    //      })     
+    // .catch(error => {
+    //              console.log('Error',error.response);
+    //                  });
+    //         }
+
+    useEffect(() => {
+        onClickShowQuestion()
+    },[])
+
+    const onClickShowQuestion = async() =>{
+                await axios.get("/api/show-question",{api_token},{csrf_token})
+                .then((res)=>{   
+                    setQuestion(res.data)
+                    console.log(res.data)
+                    }
+                        ) 
+                .catch(error => {
+                             console.log('Error',error.response);
+                                 });
+                        }  
+              
+　　//質問ごとの回答をsetStateする
+    const onChangeSetData = (e) =>{
+        e.preventDefault();
+        //questionID：answerID
+        setAnswerData([...answerData,(JSON.stringify({[e.target.name]:e.target.value}))])
+    }
+
+    //送信する関数
+    const onClickSubmit = (e) =>{
+        alert(answerData)
+    }
+
+        return(
+            <>
+            {/* <button onClick={onClickCreateQuestion}>押す</button> */}
+        
+            <ChakraProvider>
+            {question.map((q) =>
+                                       <Container key={q.id} maxW="xl" centerContent >
+                                       <ul>
+                                       <FormLabel>                     
+                                            <Badge borderRadius="full" px="2" colorScheme="teal">
+                                              {q.id}
+                                            </Badge>
+                                        </FormLabel>
+                                        <Box width="30%" height="30%">
+                                        <Image
+                                        
+                                            objectFit="cover"
+                                            src={pictures[(q.id)-1]}
+                                        />
+                                        </Box>
+                                       {q.question}
+                                       <Select placeholder="回答を選ぶ" 
+                                       name={q.id}
+                                       onChange={ onChangeSetData }>
+                                            {q.answers.map((a)=>
+                                            <option value={a.id} key={a.id}>{a.answer}</option> 
+                                            )}
+                                      </Select>
+                                      </ul> 
+            
+                                        </Container>
+                                    )}
+                                                               
+                                         <Center>
+                                             <Button leftIcon={<ArrowRightIcon />} 
+                                                onClick={onClickSubmit}
+                                                bg="#FFE3D3" size="sm">
+                                                    送信する
+                                             </Button>
+                                        </Center>
+
+                                        
+                 </ChakraProvider>
+
+            </>
+        )
+
+    }
+
+export default Hawayu;

--- a/laravel/resources/js/pages/hawayu/HawayuForm.jsx
+++ b/laravel/resources/js/pages/hawayu/HawayuForm.jsx
@@ -16,8 +16,23 @@ import question4 from './question4.png';
 
 const HawayuForm = () =>{
     const history = useHistory();
+    const  [question, setQuestion] = useState([]);
+
+    const api_token = document
+        .querySelector('meta[name="api-token"]')
+        .getAttribute("content")
+
+    const csrf_token = document
+        .querySelector('meta[name="csrf-token"]')
+        .getAttribute("content")
+        
+
+           
+
     return(
         <>
+
+
         <ButtonGroup size="sm" isAttached variant="outline" onClick ={()=>history.goBack()}>
             <IconButton aria-label="back" icon={<ArrowBackIcon />} />
             <Button mr="-px">戻る</Button>  
@@ -124,6 +139,7 @@ const HawayuForm = () =>{
                         送信する
                 </Button>
          
+        
                 </Container>
                 {/* 合計5点以下＝要相談（相談してみませんか？の文字と、チャットへのリンク（コンテンツ実装できればコンテンツを挟む） */}
                 {/* 合計6点以上＝ありがとうございました！気になることがあればお気軽に相談してくださいねの文字のみ */}

--- a/laravel/resources/js/pages/user/UserMyPage.jsx
+++ b/laravel/resources/js/pages/user/UserMyPage.jsx
@@ -17,6 +17,11 @@ function UserMyPage(props) {
     .querySelector('meta[name="api-token"]')
     .getAttribute("content");
 
+    const csrf_token = 
+    document
+    .querySelector('meta[name="csrf-token"]')
+    .getAttribute("content")
+
     useEffect(() => {
         getUser()
     },[])
@@ -34,8 +39,18 @@ function UserMyPage(props) {
                 }
 
         const history = useHistory();
-        const onClickToHawayu =()=>{ history.push('/user/hawayuform')}
+        // const onClickToHawayu =()=>{ history.push('/user/hawayuform')}
 
+        const onClickToHawayu = async() =>{
+            await axios.post("/api/create-inquiry",{api_token},{csrf_token})
+        .then((res)=>{
+            console.log("create",res.data)  
+            history.push('/user/hawayu')
+             })    
+        .catch(error => {
+                     console.log('Error',error.response);
+                         });
+                }
     return (
         <div>
         <SH1>{user.nickname}さん、こんにちは</SH1>

--- a/laravel/resources/js/routers/userRoutes.jsx
+++ b/laravel/resources/js/routers/userRoutes.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Hawayu from '../pages/hawayu/Hawayu';
 import HawayuForm from '../pages/hawayu/HawayuForm';
 import UserMyPage from "../pages/user/UserMyPage";
 
@@ -12,5 +13,10 @@ export const userRoutes = [
         path:"/hawayuform",
         exact :true,
         children:<HawayuForm />
+    },
+    {
+        path:"/hawayu",
+        exact :true,
+        children:<Hawayu />
     }
 ];


### PR DESCRIPTION
・API2点の実装

ハワユ」Button押す
→/api/create-inquiryでアンケート用紙を作成（IDが立ち、データベースに保存される）
→ページ遷移し、useEffectでapi/show-questionを実行→質問・回答・画像を表示

・Keyの名前を「A1~A4」に変更しました